### PR TITLE
Mis configured handler#48

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "workbench.colorCustomizations": {
         "activityBar.background": "#2f7c47",
+        "activityBar.activeBorder": "#422c74",
         "activityBar.foreground": "#e7e7e7",
         "activityBar.inactiveForeground": "#e7e7e799",
         "activityBarBadge.background": "#422c74",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2020-02-04 - 0.4.7
+
+- #48 Changed `PipelineNotFoundException` to internal.
+- #48 Removed sealed modified from Mediator to allow derived implementations.
+- #48 Added `OnPipelineNotFound` event.
+
 ## 2019-10-20 - 0.4.6
 
 * #25 Cancellation Token fixed.

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 - #48 Changed `PipelineNotFoundException` to internal.
 - #48 Removed sealed modified from Mediator to allow derived implementations.
-- #48 Added `OnPipelineNotFound` event.
+- #48 Added `OnPipelineNotFound` event to `IMediator` interface.
+- #48 Added `void OnPipelineNotFound(PipelineNotFoundEventArgs e)` handler to `Mediator` class.
 
 ## 2019-10-20 - 0.4.6
 

--- a/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediator.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediator.Microsoft.Extensions.DependencyInjection.csproj
@@ -20,7 +20,7 @@
 	</PropertyGroup>
 
   <ItemGroup Label="SourceLink">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Label="SourceLink">

--- a/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediator.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediator.Microsoft.Extensions.DependencyInjection.csproj
@@ -7,7 +7,7 @@
   
   <PropertyGroup>
     <PackageId>FluentMediator.Microsoft.Extensions.DependencyInjection</PackageId>
-    <Version>0.4.6</Version>
+    <Version>0.4.7</Version>
     <Authors>Ivan Paulovich</Authors>
     <Copyright>Ivan Paulovich</Copyright>
     <Description>Microsoft Extensions for FluentMediator.</Description>

--- a/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediatorExtensions.cs
+++ b/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediatorExtensions.cs
@@ -17,7 +17,7 @@ namespace FluentMediator
         public static IServiceCollection AddFluentMediator<TMediator>(
             this IServiceCollection services,
             Action<IPipelineProviderBuilder> setupAction)
-            where TMediator : class, IMediator
+        where TMediator : class, IMediator
         {
             var pipelineProviderBuilder = new PipelineProviderBuilder();
             setupAction(pipelineProviderBuilder);

--- a/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediatorExtensions.cs
+++ b/src/FluentMediator.Microsoft.Extensions.DependencyInjection/FluentMediatorExtensions.cs
@@ -14,6 +14,28 @@ namespace FluentMediator
         /// <param name="services">The ServiceCollection</param>
         /// <param name="setupAction">Builder</param>
         /// <returns>The changed ServiceCollection</returns>
+        public static IServiceCollection AddFluentMediator<TMediator>(
+            this IServiceCollection services,
+            Action<IPipelineProviderBuilder> setupAction)
+            where TMediator : class, IMediator
+        {
+            var pipelineProviderBuilder = new PipelineProviderBuilder();
+            setupAction(pipelineProviderBuilder);
+            var pipelineProvider = pipelineProviderBuilder.Build();
+
+            services.AddTransient<GetService>(c => c.GetService);
+            services.AddTransient(c => pipelineProvider);
+            services.AddTransient<IMediator, TMediator>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the FluentMediator
+        /// </summary>
+        /// <param name="services">The ServiceCollection</param>
+        /// <param name="setupAction">Builder</param>
+        /// <returns>The changed ServiceCollection</returns>
         public static IServiceCollection AddFluentMediator(this IServiceCollection services, Action<IPipelineProviderBuilder> setupAction)
         {
             var pipelineProviderBuilder = new PipelineProviderBuilder();

--- a/src/FluentMediator/FluentMediator.csproj
+++ b/src/FluentMediator/FluentMediator.csproj
@@ -11,7 +11,7 @@
 
 	<PropertyGroup>
     <PackageId>FluentMediator</PackageId>
-    <Version>0.4.6</Version>
+    <Version>0.4.7</Version>
     <Authors>Ivan Paulovich</Authors>
     <Copyright>Ivan Paulovich</Copyright>
     <Description>FluentMediator is an unobtrusive library that allows developers to build custom pipelines for Commands, Queries and Events.</Description>

--- a/src/FluentMediator/FluentMediator.csproj
+++ b/src/FluentMediator/FluentMediator.csproj
@@ -24,7 +24,7 @@
 	</PropertyGroup>
 
   <ItemGroup Label="SourceLink">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup Label="SourceLink">

--- a/src/FluentMediator/IMediator.cs
+++ b/src/FluentMediator/IMediator.cs
@@ -12,10 +12,10 @@ namespace FluentMediator
         ISyncMediator,
         IAsyncMediator,
         ICancellableMediator
-    {
-        /// <summary>
-        /// On Pipeline Not Found Event Handler.
-        /// </summary>
-        event EventHandler<PipelineNotFoundEventArgs>? PipelineNotFound;
-    }
+        {
+            /// <summary>
+            /// On Pipeline Not Found Event Handler.
+            /// </summary>
+            event EventHandler<PipelineNotFoundEventArgs> ? PipelineNotFound;
+        }
 }

--- a/src/FluentMediator/IMediator.cs
+++ b/src/FluentMediator/IMediator.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentMediator.Pipelines.CancellablePipelineAsync;
 using FluentMediator.Pipelines.Pipeline;
 using FluentMediator.Pipelines.PipelineAsync;
@@ -10,5 +11,11 @@ namespace FluentMediator
     public interface IMediator:
         ISyncMediator,
         IAsyncMediator,
-        ICancellableMediator { }
+        ICancellableMediator
+    {
+        /// <summary>
+        /// On Pipeline Not Found Event Handler.
+        /// </summary>
+        event EventHandler<PipelineNotFoundEventArgs>? PipelineNotFound;
+    }
 }

--- a/src/FluentMediator/Mediator.cs
+++ b/src/FluentMediator/Mediator.cs
@@ -21,7 +21,7 @@ namespace FluentMediator
         /// <summary>
         /// On Pipeline Not Found Handler.
         /// </summary>
-        public event EventHandler<PipelineNotFoundEventArgs>? PipelineNotFound;
+        public event EventHandler<PipelineNotFoundEventArgs> ? PipelineNotFound;
 
         /// <summary>
         /// Instantiate a Mediator

--- a/src/FluentMediator/Mediator.cs
+++ b/src/FluentMediator/Mediator.cs
@@ -1,19 +1,27 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentMediator.Pipelines;
 
 namespace FluentMediator
 {
     /// <summary>
     /// Publishes/Sends messages through the Pipelines
     /// </summary>
-    public sealed class Mediator : IMediator
+    public class Mediator : IMediator
     {
         /// <summary>
         /// Returns a service from the Container
         /// </summary>
         /// <value></value>
         public GetService GetService { get; }
+
         private IPipelineProvider _pipelines;
+
+        /// <summary>
+        /// On Pipeline Not Found Handler.
+        /// </summary>
+        public event EventHandler<PipelineNotFoundEventArgs>? PipelineNotFound;
 
         /// <summary>
         /// Instantiate a Mediator
@@ -40,16 +48,23 @@ namespace FluentMediator
                 throw new NullRequestException("The request is null.");
             }
 
-            if (pipelineName is string)
+            try
             {
-                var pipeline = _pipelines.GetPipeline(pipelineName);
-                pipeline.Publish(GetService, request!);
-
+                if (pipelineName is string)
+                {
+                    var pipeline = _pipelines.GetPipeline(pipelineName);
+                    pipeline.Publish(GetService, request!);
+                }
+                else
+                {
+                    var pipeline = _pipelines.GetPipeline(request.GetType());
+                    pipeline.Publish(GetService, request!);
+                }
             }
-            else
+            catch (PipelineNotFoundException)
             {
-                var pipeline = _pipelines.GetPipeline(request.GetType());
-                pipeline.Publish(GetService, request!);
+                var e = new PipelineNotFoundEventArgs(request);
+                OnPipelineNotFound(e);
             }
         }
 
@@ -180,6 +195,18 @@ namespace FluentMediator
             {
                 var pipeline = _pipelines.GetCancellablePipeline(request.GetType());
                 return await pipeline.SendAsync<TResult>(GetService, request, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// On Pipeline Not Found.
+        /// </summary>
+        /// <param name="e">OnErrorEventArgs.</param>
+        protected virtual void OnPipelineNotFound(PipelineNotFoundEventArgs e)
+        {
+            if (this.PipelineNotFound is EventHandler<PipelineNotFoundEventArgs>)
+            {
+                this.PipelineNotFound(this, e);
             }
         }
     }

--- a/src/FluentMediator/PipelineNotFoundEventArgs.cs
+++ b/src/FluentMediator/PipelineNotFoundEventArgs.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace FluentMediator
+{
+    /// <summary>
+    /// On Error Event.
+    /// </summary>
+    public class PipelineNotFoundEventArgs : EventArgs
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value></value>
+        public object Message { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        public PipelineNotFoundEventArgs(object message)
+        {
+            this.Message = message;
+        }
+    }
+}

--- a/src/FluentMediator/Pipelines/CancellablePipelineAsync/ICancellableMediator.cs
+++ b/src/FluentMediator/Pipelines/CancellablePipelineAsync/ICancellableMediator.cs
@@ -16,7 +16,7 @@ namespace FluentMediator.Pipelines.CancellablePipelineAsync
         /// <param name="pipelineName">Pipeline Name</param>
         /// <returns>Task object</returns>
         Task PublishAsync(object request, CancellationToken cancellationToken, string? pipelineName = null);
-        
+
         /// <summary>
         /// Sends a message
         /// </summary>

--- a/src/FluentMediator/Pipelines/CancellablePipelineAsync/ICancellablePipelineProvider.cs
+++ b/src/FluentMediator/Pipelines/CancellablePipelineAsync/ICancellablePipelineProvider.cs
@@ -13,7 +13,7 @@ namespace FluentMediator.Pipelines.CancellablePipelineAsync
         /// <param name="requestType"></param>
         /// <returns></returns>
         ICancellablePipelineAsync GetCancellablePipeline(Type requestType);
-        
+
         /// <summary>
         /// 
         /// </summary>

--- a/src/FluentMediator/Pipelines/Pipeline/IPipeline.cs
+++ b/src/FluentMediator/Pipelines/Pipeline/IPipeline.cs
@@ -11,7 +11,7 @@ namespace FluentMediator.Pipelines.Pipeline
         /// <param name="getService"></param>
         /// <param name="request"></param>
         void Publish(GetService getService, object request);
-        
+
         /// <summary>
         /// 
         /// </summary>

--- a/src/FluentMediator/Pipelines/PipelineNotFoundException.cs
+++ b/src/FluentMediator/Pipelines/PipelineNotFoundException.cs
@@ -3,7 +3,7 @@ namespace FluentMediator.Pipelines
     /// <summary>
     /// Occurs when a pipeline for a message was not found
     /// </summary>
-    public sealed class PipelineNotFoundException : MediatorException
+    internal sealed class PipelineNotFoundException : MediatorException
     {
         /// <summary>
         /// Instantiate a PipelineNotFoundException

--- a/test/UnitTests/BuildingMediatorTests.cs
+++ b/test/UnitTests/BuildingMediatorTests.cs
@@ -13,7 +13,7 @@ namespace UnitTests
         public void BuildSendAsyncPipeline_ThrowsPipelineAlreadyExistsException()
         {
             var services = new ServiceCollection();
-            
+
             var pipelineProviderBuilder = new PipelineProviderBuilder();
 
             pipelineProviderBuilder.On<PingRequest>().PipelineAsync()

--- a/test/UnitTests/MyCustomMediator.cs
+++ b/test/UnitTests/MyCustomMediator.cs
@@ -2,21 +2,20 @@ using FluentMediator;
 
 namespace UnitTests
 {
-public class MyCustomMediator : Mediator
-{
-    public bool MyCustomPipelineNotFoundHandlerWasCalled = false;
-    
-    public MyCustomMediator(GetService getService, IPipelineProvider pipelines) : base(getService, pipelines)
+    public class MyCustomMediator : Mediator
     {
-    }
+        public bool MyCustomPipelineNotFoundHandlerWasCalled = false;
 
-    protected override void OnPipelineNotFound(PipelineNotFoundEventArgs e)
-    {
-        MyCustomPipelineNotFoundHandlerWasCalled = true;
+        public MyCustomMediator(GetService getService, IPipelineProvider pipelines) : base(getService, pipelines)
+        { }
 
-        //Do something before raising the event
-        base.OnPipelineNotFound(e);
-        //Do something after raising the event 
+        protected override void OnPipelineNotFound(PipelineNotFoundEventArgs e)
+        {
+            MyCustomPipelineNotFoundHandlerWasCalled = true;
+
+            //Do something before raising the event
+            base.OnPipelineNotFound(e);
+            //Do something after raising the event 
+        }
     }
-}
 }

--- a/test/UnitTests/MyCustomMediator.cs
+++ b/test/UnitTests/MyCustomMediator.cs
@@ -2,21 +2,21 @@ using FluentMediator;
 
 namespace UnitTests
 {
-    public class MyCustomMediator : Mediator
+public class MyCustomMediator : Mediator
+{
+    public bool MyCustomPipelineNotFoundHandlerWasCalled = false;
+    
+    public MyCustomMediator(GetService getService, IPipelineProvider pipelines) : base(getService, pipelines)
     {
-        public bool MyCustomPipelineNotFoundHandlerWasCalled = false;
-        
-        public MyCustomMediator(GetService getService, IPipelineProvider pipelines) : base(getService, pipelines)
-        {
-        }
-
-        protected override void OnPipelineNotFound(PipelineNotFoundEventArgs e)
-        {
-            MyCustomPipelineNotFoundHandlerWasCalled = true;
-
-            //Do something before raising the event
-            base.OnPipelineNotFound(e);
-            //Do something after raising the event 
-        }
     }
+
+    protected override void OnPipelineNotFound(PipelineNotFoundEventArgs e)
+    {
+        MyCustomPipelineNotFoundHandlerWasCalled = true;
+
+        //Do something before raising the event
+        base.OnPipelineNotFound(e);
+        //Do something after raising the event 
+    }
+}
 }

--- a/test/UnitTests/MyCustomMediator.cs
+++ b/test/UnitTests/MyCustomMediator.cs
@@ -1,0 +1,22 @@
+using FluentMediator;
+
+namespace UnitTests
+{
+    public class MyCustomMediator : Mediator
+    {
+        public bool MyCustomPipelineNotFoundHandlerWasCalled = false;
+        
+        public MyCustomMediator(GetService getService, IPipelineProvider pipelines) : base(getService, pipelines)
+        {
+        }
+
+        protected override void OnPipelineNotFound(PipelineNotFoundEventArgs e)
+        {
+            MyCustomPipelineNotFoundHandlerWasCalled = true;
+
+            //Do something before raising the event
+            base.OnPipelineNotFound(e);
+            //Do something after raising the event 
+        }
+    }
+}

--- a/test/UnitTests/PublishingRequestsTests.cs
+++ b/test/UnitTests/PublishingRequestsTests.cs
@@ -44,7 +44,7 @@ namespace UnitTests
             services.AddFluentMediator(builder =>
             {
                 builder.On<PingRequest>().PipelineAsync()
-                    .Call<IPingHandler>(async (handler, req) => await handler.MyCustomFooBarAsync(req))
+                    .Call<IPingHandler>(async(handler, req) => await handler.MyCustomFooBarAsync(req))
                     .Build();
             });
             var pingHandler = new Mock<IPingHandler>();
@@ -71,7 +71,7 @@ namespace UnitTests
             services.AddFluentMediator(builder =>
             {
                 builder.On<PingRequest>().CancellablePipelineAsync()
-                    .Call<IPingHandler>(async (handler, req, ct) => await handler.MyCancellableForAsync(req, ct))
+                    .Call<IPingHandler>(async(handler, req, ct) => await handler.MyCancellableForAsync(req, ct))
                     .Build();
             });
             var pingHandler = new Mock<IPingHandler>();
@@ -98,9 +98,9 @@ namespace UnitTests
             services.AddFluentMediator(builder =>
             {
                 builder.On<PingRequest>().CancellablePipelineAsync()
-                    .Call<IPingHandler>(async (handler, req, ct) => await handler.MyCancellableForAsync(req, ct))
+                    .Call<IPingHandler>(async(handler, req, ct) => await handler.MyCancellableForAsync(req, ct))
                     .Return<PingResponse, IPingHandler>(
-                        async (handler, req, ct) => await handler.MyCancellableForAsync(req, ct)
+                        async(handler, req, ct) => await handler.MyCancellableForAsync(req, ct)
                     );
             });
             var pingHandler = new Mock<IPingHandler>();
@@ -133,7 +133,8 @@ namespace UnitTests
             bool myCustomPipelineNotFoundHandlerWasCalled = false;
 
             // This is handler is called for every message without a destination pipeline.
-            mediator.PipelineNotFound += (object sender, PipelineNotFoundEventArgs e) => {
+            mediator.PipelineNotFound += (object sender, PipelineNotFoundEventArgs e) =>
+            {
                 myCustomPipelineNotFoundHandlerWasCalled = true;
             };
 
@@ -151,12 +152,12 @@ namespace UnitTests
         public void Publish_CallsCustomPipelineNotFound_WhenHandlerIsNotSetup()
         {
             var services = new ServiceCollection();
-            
+
             // Mediator Without the Handler for PingRequest.
             services.AddFluentMediator<MyCustomMediator>(builder => { });
 
             var provider = services.BuildServiceProvider();
-            var mediator = (MyCustomMediator)provider.GetRequiredService<IMediator>();
+            var mediator = (MyCustomMediator) provider.GetRequiredService<IMediator>();
 
             var cts = new CancellationTokenSource();
             var ping = new PingRequest("Cancellable Async Ping");

--- a/test/UnitTests/PublishingRequestsTests.cs
+++ b/test/UnitTests/PublishingRequestsTests.cs
@@ -1,7 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using FluentMediator;
-using FluentMediator.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using UnitTests.PingPong;
@@ -122,41 +121,7 @@ namespace UnitTests
         }
 
         [Fact]
-        public async Task PublishAsync_ThrowsPipelineNotFoundException_WhenHandlerIsNotSetup()
-        {
-            var services = new ServiceCollection();
-            // Mediator Without the Handler for PingRequest
-            services.AddFluentMediator(builder => { });
-
-            var provider = services.BuildServiceProvider();
-            var mediator = provider.GetRequiredService<IMediator>();
-
-            var cts = new CancellationTokenSource();
-            var ping = new PingRequest("Cancellable Async Ping");
-
-            var actualEx = await Record.ExceptionAsync(async () => await mediator.PublishAsync(ping, cts.Token));
-            Assert.IsType<PipelineNotFoundException>(actualEx);
-        }
-
-        [Fact]
-        public void Publish_ThrowsPipelineNotFoundException_WhenHandlerIsNotSetup()
-        {
-            var services = new ServiceCollection();
-            // Mediator Without the Handler for PingRequest
-            services.AddFluentMediator(builder => { });
-
-            var provider = services.BuildServiceProvider();
-            var mediator = provider.GetRequiredService<IMediator>();
-
-            var cts = new CancellationTokenSource();
-            var ping = new PingRequest("Cancellable Async Ping");
-
-            var actualEx = Record.Exception(() => mediator.Publish(ping));
-            Assert.IsType<PipelineNotFoundException>(actualEx);
-        }
-
-        [Fact]
-        public void Publish_CallsOnPipelineNotFound_WhenHandlerIsNotSetup()
+        public void Publish_CallsPipelineNotFound_WhenHandlerIsNotSetup()
         {
             var services = new ServiceCollection();
             // Mediator Without the Handler for PingRequest.
@@ -180,6 +145,27 @@ namespace UnitTests
 
             // The method was called :)
             Assert.True(myCustomPipelineNotFoundHandlerWasCalled);
+        }
+
+        [Fact]
+        public void Publish_CallsCustomPipelineNotFound_WhenHandlerIsNotSetup()
+        {
+            var services = new ServiceCollection();
+            
+            // Mediator Without the Handler for PingRequest.
+            services.AddFluentMediator<MyCustomMediator>(builder => { });
+
+            var provider = services.BuildServiceProvider();
+            var mediator = (MyCustomMediator)provider.GetRequiredService<IMediator>();
+
+            var cts = new CancellationTokenSource();
+            var ping = new PingRequest("Cancellable Async Ping");
+
+            // Should run without throwing exceptions
+            mediator.Publish(ping);
+
+            // The method was called :)
+            Assert.True(mediator.MyCustomPipelineNotFoundHandlerWasCalled);
         }
     }
 }

--- a/test/UnitTests/SendingRequestTests.cs
+++ b/test/UnitTests/SendingRequestTests.cs
@@ -61,7 +61,7 @@ namespace UnitTests
                 //
                 // Act
                 //
-                async () => await mediator.SendAsync<PingResponse>(ping)
+                async() => await mediator.SendAsync<PingResponse>(ping)
             );
 
             Assert.IsType<ReturnFunctionIsNullException>(actualEx.Result);
@@ -93,7 +93,7 @@ namespace UnitTests
                 //
                 // Act
                 //
-                async () => await mediator.SendAsync<PingResponse>(ping, cts.Token)
+                async() => await mediator.SendAsync<PingResponse>(ping, cts.Token)
             );
 
             Assert.IsType<ReturnFunctionIsNullException>(actualEx.Result);
@@ -232,8 +232,7 @@ namespace UnitTests
         public void Send_Throws_Exception_Null_Requests()
         {
             var services = new ServiceCollection();
-            services.AddFluentMediator(m =>
-            { });
+            services.AddFluentMediator(m => { });
 
             services.AddScoped<IPingHandler, PingHandler>();
             var provider = services.BuildServiceProvider();

--- a/test/UnitTests/SendingRequestTests.cs
+++ b/test/UnitTests/SendingRequestTests.cs
@@ -229,24 +229,6 @@ namespace UnitTests
         }
 
         [Fact]
-        public void Send_Not_Configured_Throws_PipelineNotFoundException()
-        {
-            var services = new ServiceCollection();
-            services.AddFluentMediator(m =>
-            { });
-
-            services.AddScoped<IPingHandler, PingHandler>();
-            var provider = services.BuildServiceProvider();
-            var mediator = provider.GetRequiredService<IMediator>();
-
-            var ping = new PingRequest("Ping");
-            var actualEx = Record.Exception(() => mediator.Send<PingResponse>(ping));
-
-            Assert.NotNull(actualEx);
-            Assert.IsType<PipelineNotFoundException>(actualEx);
-        }
-
-        [Fact]
         public void Send_Throws_Exception_Null_Requests()
         {
             var services = new ServiceCollection();

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
- #48 Changed `PipelineNotFoundException` to internal.
- #48 Removed sealed modified from Mediator to allow derived implementations.
- #48 Added `OnPipelineNotFound` event to `IMediator` interface.
- #48 Added `void OnPipelineNotFound(PipelineNotFoundEventArgs e)` handler to `Mediator` class.